### PR TITLE
Fix inaccurate task names

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,11 @@
 
 - include: profiles.yml
 
-- name: enable systemd-networkd and systemd-resolved
+- name: enable systemd-networkd
   service: name=systemd-networkd enabled=yes
   when: systemd_networkd_network or systemd_networkd_link or systemd_networkd_netdev
 
-- name: enable systemd-resolved
+- name: start and enable systemd-resolved
   service: name=systemd-resolved enabled=yes state=started
   when: systemd_networkd_enable_resolved
 


### PR DESCRIPTION
You missed the edit of task names when splitting the management of `systemd-networkd` and `systemd-resolved`.
This patch corrects it.