### PR TITLE
Modernize syntax, loop handling and add handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# handlers for ansible-role-systemd-networkd
+
+- name: restart systemd-networkd
+  service:
+    name: systemd-networkd
+    state: restarted
+  when: systemd_networkd_apply_config

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Anthony Ruhier"
   description: Configures systemd-networkd profiles
   license: BSD
-  min_ansible_version: 2.0
+  min_ansible_version: 2.5
   platforms:
   - name: EL
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,8 +10,4 @@
   service: name=systemd-resolved enabled=yes state=started
   when: systemd_networkd_enable_resolved
 
-- name: restart systemd-networkd
-  service: name="systemd-networkd" state=restarted
-  when: systemd_networkd_apply_config
-
 # vim: set ts=2 sw=2:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,24 @@
 ---
 
-- include: profiles.yml
+- import_tasks: profiles.yml
 
 - name: enable systemd-networkd
-  service: name=systemd-networkd enabled=yes
+  service:
+    name: systemd-networkd
+    enabled: yes
   when: systemd_networkd_network or systemd_networkd_link or systemd_networkd_netdev
 
 - name: start and enable systemd-resolved
-  service: name=systemd-resolved enabled=yes state=started
+  service:
+    name: systemd-resolved
+    enabled: yes
+    state: started
   when: systemd_networkd_enable_resolved
 
 - name: restart systemd-networkd
-  service: name="systemd-networkd" state=restarted
+  service:
+    name: systemd-networkd
+    state: restarted
   when: systemd_networkd_apply_config
 
 # vim: set ts=2 sw=2:

--- a/tasks/profiles.yml
+++ b/tasks/profiles.yml
@@ -5,20 +5,20 @@
     src: "systemd_networkd_profile.j2"
     dest: "/etc/systemd/network/{{ item.key }}.link"
     mode: 0644
-  with_dict: "{{ systemd_networkd_link }}"
+  loop: "{{ systemd_networkd_link | dict2items }}"
 
 - name: copy .netdev profiles
   template:
     src: "systemd_networkd_profile.j2"
     dest: "/etc/systemd/network/{{ item.key }}.netdev"
     mode: 0644
-  with_dict: "{{ systemd_networkd_netdev }}"
+  loop: "{{ systemd_networkd_netdev | dict2items }}"
 
 - name: copy .network profiles
   template:
     src: "systemd_networkd_profile.j2"
     dest: "/etc/systemd/network/{{ item.key }}.network"
     mode: 0644
-  with_dict: "{{ systemd_networkd_network }}"
+  loop: "{{ systemd_networkd_network | dict2items }}"
 
 # vim: set ts=2 sw=2:

--- a/tasks/profiles.yml
+++ b/tasks/profiles.yml
@@ -6,6 +6,7 @@
     dest: "/etc/systemd/network/{{ item.key }}.link"
     mode: 0644
   with_dict: "{{ systemd_networkd_link }}"
+  notify: restart systemd-networkd
 
 - name: copy .netdev profiles
   template:
@@ -13,6 +14,7 @@
     dest: "/etc/systemd/network/{{ item.key }}.netdev"
     mode: 0644
   with_dict: "{{ systemd_networkd_netdev }}"
+  notify: restart systemd-networkd
 
 - name: copy .network profiles
   template:
@@ -20,5 +22,6 @@
     dest: "/etc/systemd/network/{{ item.key }}.network"
     mode: 0644
   with_dict: "{{ systemd_networkd_network }}"
+  notify: restart systemd-networkd
 
 # vim: set ts=2 sw=2:


### PR DESCRIPTION
First of all: thanks for your code! :+1: 

I performed some maintenance on it by:
- adapted to the more modern syntax
- replaced the to-be-deprecated `with_` loop statements with the newer `loop` statements
- added a handler instead of a strictly boolean defined restart of `systemd-networkd` to improve idempotency.

Functionally this does not change your code (except for taking out unnecessary restarts), just brings the code more up to date. Which is why I made this pull request to contribute back and help this role into the future.

I plan on making other changes (in my fork) in the future that add functionality and might reorganize the structure a bit. If you are interested in those changes please let me know.