### PR TITLE
Restrict permissions for the created files

### DIFF
--- a/tasks/profiles.yml
+++ b/tasks/profiles.yml
@@ -4,7 +4,9 @@
   template:
     src: "systemd_networkd_profile.j2"
     dest: "/etc/systemd/network/{{ item.key }}.link"
-    mode: 0644
+    owner: root
+    group: systemd-network
+    mode: 0640
   loop: "{{ systemd_networkd_link | dict2items }}"
   notify: restart systemd-networkd
 
@@ -12,7 +14,9 @@
   template:
     src: "systemd_networkd_profile.j2"
     dest: "/etc/systemd/network/{{ item.key }}.netdev"
-    mode: 0644
+    owner: root
+    group: systemd-network
+    mode: 0640
   loop: "{{ systemd_networkd_netdev | dict2items }}"
   notify: restart systemd-networkd
 
@@ -20,7 +24,9 @@
   template:
     src: "systemd_networkd_profile.j2"
     dest: "/etc/systemd/network/{{ item.key }}.network"
-    mode: 0644
+    owner: root
+    group: systemd-network
+    mode: 0640
   loop: "{{ systemd_networkd_network | dict2items }}"
   notify: restart systemd-networkd
 


### PR DESCRIPTION
When creating wireguard interfaces, there is a private key in the
.netdev file and networkd will refuse to create the device:

```
systemd-networkd[298]: /etc/systemd/network/wg0.netdev has 0644 mode that is too permissive, please adjust the ownership and access mode.
```

This PR sets the mode of the files to 640 and ensures they are readable by root:systemd-network only