### PR TITLE
Add task to manage the resolv.conf symlink

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,5 +6,6 @@ systemd_networkd_network: {}
 
 systemd_networkd_apply_config: false
 systemd_networkd_enable_resolved: true
+systemd_networkd_symlink_resolv_conf: true
 
 # vim: set ts=2 sw=2:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,4 +15,12 @@
     state: started
   when: systemd_networkd_enable_resolved
 
+- name: replace /etc/resolv.conf with a symlink to the systemd-resolved stub
+  file:
+    path: /etc/resolv.conf
+    src: /run/systemd/resolve/stub-resolv.conf
+    state: link
+    force: yes
+  when: systemd_networkd_symlink_resolv_conf
+
 # vim: set ts=2 sw=2:

--- a/templates/systemd_networkd_profile.j2
+++ b/templates/systemd_networkd_profile.j2
@@ -1,4 +1,4 @@
-#{{ ansible_managed }}
+# {{ ansible_managed }}
 
 {% for section_dict in item.value %}
 {% for section, options in section_dict.items() %}


### PR DESCRIPTION
systemd-resolved supports two modes of managing `/etc/resolv.conf` and the symlink is the recommended one, see the [Arch wiki](https://wiki.archlinux.org/index.php/Systemd-resolved#DNS). Since this role manages the systemd-resolved service, it should provide a way to manage the symlink as well.