### PR TITLE
fix: use comment filter for ansible_managed block

### DIFF
--- a/templates/nsswitch.conf.j2
+++ b/templates/nsswitch.conf.j2
@@ -1,4 +1,5 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
+
 passwd:    {{ systemd_networkd_nsswitch_passwd }}
 group:     {{ systemd_networkd_nsswitch_group }}
 shadow:    {{ systemd_networkd_nsswitch_shadow }}

--- a/templates/systemd_networkd_config.j2
+++ b/templates/systemd_networkd_config.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% for section_dict in item.1.value %}
 {% for section, options in section_dict.items() %}


### PR DESCRIPTION
Add `comment` filter to templates [1].

This is required if the `ansible_managed` string is spanning over multiple lines, configured in - for example - `ansible.cfg`:

```ini
ansible_managed = This file is managed by Ansible.%n
  template: {file}
  date: %Y-%m-%d %H:%M:%S
  user: {uid}
  host: {host}
```

This would result in:

```sh
root@host ~# cat /etc/systemd/network/eth0.network
#
# This file is managed by Ansible.
#
# template: systemd_networkd_config.j2
# date: 2023-05-26 17:06:01
# user: xxx
# host: xxx
#
```

instead of: (invalid syntax)

```sh
root@host ~# cat /etc/systemd/network/eth0.network
# This file is managed by Ansible.

template: systemd_networkd_config.j2
date: 2023-05-26 17:06:01
user: xxx
host: xxx
```

[1]: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#adding-comments-to-files