### PR TITLE
Add route tables feature & systemd-network conf file type

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,10 @@
 systemd_networkd_link: {}
 systemd_networkd_netdev: {}
 systemd_networkd_network: {}
+systemd_networkd_conf: {}
+
+systemd_networkd_conf_directory: /etc/systemd/networkd.conf.d/
+
 systemd_networkd_apply_config: false
 systemd_networkd_enable_resolved: true
 systemd_networkd_symlink_resolv_conf: true
@@ -27,5 +31,5 @@ systemd_networkd_nsswitch_aliases: files
 systemd_networkd_nsswitch_publickey: files
 
 systemd_networkd_rt_tables: []
-systemd_networkd_rttables_conf_path: "/etc/iproute2/rt_tables.d"
+systemd_networkd_rttables_conf_file: "/etc/iproute2/rt_tables"
 # vim: set ts=2 sw=2:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,8 @@ systemd_networkd_netdev: {}
 systemd_networkd_network: {}
 systemd_networkd_conf: {}
 
-systemd_networkd_conf_directory: /etc/systemd/networkd.conf.d/
+systemd_networkd_directory: /etc/systemd/network
+systemd_networkd_conf_directory: /etc/systemd/networkd.conf.d
 
 systemd_networkd_apply_config: false
 systemd_networkd_enable_resolved: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,4 +26,6 @@ systemd_networkd_nsswitch_automount: files
 systemd_networkd_nsswitch_aliases: files
 systemd_networkd_nsswitch_publickey: files
 
+systemd_networkd_rt_tables: []
+systemd_networkd_rttables_conf_path: "/etc/iproute2/rt_tables.d"
 # vim: set ts=2 sw=2:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,4 +6,5 @@
   ansible.builtin.systemd:
     name: systemd-networkd
     state: restarted
+    daemon-reload: true
   when: systemd_networkd_apply_config

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,4 +1,17 @@
 ---
+- name: Create route table if necessary
+  become: true
+  template:
+    src: "rt_tables.j2"
+    dest: "{{ systemd_networkd_rttables_conf_path }}/{{ item.name }}.conf"
+    owner: root
+    group: root
+    mode: 0640
+  loop: "{{ systemd_networkd_rt_tables }}"
+  loop_control:
+    id: "{{ item.id }}"
+    name: "{{ item.name }}"
+
 - name: Ensure systemd-networkd configuration files exist
   become: true
   vars:
@@ -41,5 +54,4 @@
 - name: Set systemd_networkd_nssswitch_changed task
   ansible.builtin.set_fact:
     systemd_networkd_nssswitch_changed: "{{ systemd_networkd_nssswitch_changed }}"
-
 # vim: set ts=2 sw=2:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,30 +7,6 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK"
   loop: "{{ systemd_networkd_rt_tables }}"
 
-- name: Ensure systemd-networkd configuration files exist
-  become: true
-  vars:
-    # Profiles to iterate over. Using a single looped task is more performant
-    # than multiple tasks.
-    all_files:
-      - type: link
-        files: "{{ systemd_networkd_link | dict2items }}"
-      - type: netdev
-        files: "{{ systemd_networkd_netdev | dict2items }}"
-      - type: network
-        files: "{{ systemd_networkd_network | dict2items }}"
-  ansible.builtin.template:
-    src: systemd_networkd_config.j2
-    dest: /etc/systemd/network/{{ item.1.key }}.{{ item.0.type }}
-    owner: root
-    group: systemd-network
-    mode: "0640"
-  loop: "{{ query('subelements', all_files, 'files') }}"
-  loop_control:
-    label: "type: {{ item.0.type }}, name: {{ item.1.key }}"
-  notify: Restart systemd-networkd
-  register: systemd_networkd_status
-
 - name: Create systemd conf folder
   become: true
   ansible.builtin.file:
@@ -40,24 +16,35 @@
     owner: root
     group: root
 
-- name: Systemd configuration files exist
+- name: Ensure systemd-networkd configuration files exist
   become: true
   vars:
+    # Profiles to iterate over. Using a single looped task is more performant
+    # than multiple tasks.
     all_files:
+      - type: link
+        files: "{{ systemd_networkd_link | dict2items }}"
+        dest_folder: "{{ systemd_networkd_directory }}"
+      - type: netdev
+        files: "{{ systemd_networkd_netdev | dict2items }}"
+        dest_folder: "{{ systemd_networkd_directory }}"
+      - type: network
+        files: "{{ systemd_networkd_network | dict2items }}"
+        dest_folder: "{{ systemd_networkd_directory }}"
       - type: conf
         files: "{{ systemd_networkd_conf | dict2items }}"
-  template:
-    src: "systemd_networkd_config.j2"
-    dest: "{{ systemd_networkd_conf_directory }}/{{ item.1.key }}.{{ item.0.type }}"
+        dest_folder: "{{ systemd_networkd_conf_directory }}"
+  ansible.builtin.template:
+    src: systemd_networkd_config.j2
+    dest: "{{ item.0.dest_folder }}/{{ item.1.key }}.{{ item.0.type }}"
     owner: root
     group: systemd-network
-    mode: 0640
-  loop: "{{ query('subelements', all_files, 'files' ) }}"
+    mode: "0640"
+  loop: "{{ query('subelements', all_files, 'files') }}"
   loop_control:
-    label:
-      type: "{{ item.0.type }}"
-      name: "{{ item.1.key }}"
-  notify: restart systemd-networkd
+    label: "type: {{ item.0.type }}, name: {{ item.1.key }}"
+  notify: Restart systemd-networkd
+  register: systemd_networkd_status
 
 - name: Set systemd_network_status task
   ansible.builtin.set_fact:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,16 +1,11 @@
 ---
 - name: Create route table if necessary
   become: true
-  template:
-    src: "rt_tables.j2"
-    dest: "{{ systemd_networkd_rttables_conf_path }}/{{ item.name }}.conf"
-    owner: root
-    group: root
-    mode: 0640
+  ansible.builtin.blockinfile:
+    path: "{{ systemd_networkd_rttables_conf_file }}"
+    block: "{{ lookup('template', 'rt_tables.j2') }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
   loop: "{{ systemd_networkd_rt_tables }}"
-  loop_control:
-    id: "{{ item.id }}"
-    name: "{{ item.name }}"
 
 - name: Ensure systemd-networkd configuration files exist
   become: true
@@ -35,6 +30,34 @@
     label: "type: {{ item.0.type }}, name: {{ item.1.key }}"
   notify: Restart systemd-networkd
   register: systemd_networkd_status
+
+- name: Create systemd conf folder
+  become: true
+  ansible.builtin.file:
+    path: "{{ systemd_networkd_conf_directory }}"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Systemd configuration files exist
+  become: true
+  vars:
+    all_files:
+      - type: conf
+        files: "{{ systemd_networkd_conf | dict2items }}"
+  template:
+    src: "systemd_networkd_config.j2"
+    dest: "{{ systemd_networkd_conf_directory }}/{{ item.1.key }}.{{ item.0.type }}"
+    owner: root
+    group: systemd-network
+    mode: 0640
+  loop: "{{ query('subelements', all_files, 'files' ) }}"
+  loop_control:
+    label:
+      type: "{{ item.0.type }}"
+      name: "{{ item.1.key }}"
+  notify: restart systemd-networkd
 
 - name: Set systemd_network_status task
   ansible.builtin.set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,5 +29,4 @@
     state: link
     force: true
   when: systemd_networkd_symlink_resolv_conf
-
 # vim: set ts=2 sw=2:

--- a/templates/rt_tables.j2
+++ b/templates/rt_tables.j2
@@ -1,2 +1,3 @@
-# {{ ansible_managed }}
+{% for item in systemd_networkd_rt_tables %}
 {{ item.id }} {{ item.name }}
+{% endfor %}

--- a/templates/rt_tables.j2
+++ b/templates/rt_tables.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+{{ item.id }} {{ item.name }}


### PR DESCRIPTION
Add the possibility to add custom route tables.
For these new routes tables to be taken into account by systemd-networkd, I had to add `.conf` file type.