### PR TITLE
Quote octal mode in tasks/config.yml, run ansible-lint on pushes and PRs

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,7 @@
 ---
 profile: production
 skip_list: [role-name]
+
+exclude_paths:
+  - .cache/
+  - .github/

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,18 @@
+name: check_pr
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: run-ansible-lint
+        uses: ansible/ansible-lint@v24.2.1
+

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,7 +12,7 @@
   ansible.builtin.file:
     path: "{{ systemd_networkd_conf_directory }}"
     state: directory
-    mode: 0755
+    mode: "0755"
     owner: root
     group: root
 


### PR DESCRIPTION
Octal modes must be quoted in order to be interpreted correctly.
Also, running ansible-lint on PR should prevent such issues from occurring.