### PR TITLE
Correct networkd enablement check to use booleans

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   ansible.builtin.systemd:
     name: systemd-networkd
     enabled: true
-  when: systemd_networkd_network or systemd_networkd_link or systemd_networkd_netdev
+  when: (systemd_networkd_network | length > 0) or (systemd_networkd_link | length > 0) or (systemd_networkd_netdev | length > 0)
 
 - name: Start and enable systemd-resolved
   become: true


### PR DESCRIPTION
`when` wants a boolean and using the dicts does evaluate to `True` in a boolean context. Newer versions of ansible however have decided that it wants us to give it an actual boolean instead of something that can become one.

Check explicitly for the dicts being defined by adding `is defined` to each of the named dicts.

---

This seems to have started being an issue with my machine updating to ansible 12 which landed not long ago in Debian testing.